### PR TITLE
Handle openssl not present

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 export enum ErrorCode {
+    // card errors
     ERROR = 100,
     DATA_FILE_NOT_FOUND,
     SCHEMA_FILE_NOT_FOUND,
@@ -24,6 +25,7 @@ export enum ErrorCode {
     INVALID_FILE_EXTENSION,
     TRAILING_CHARACTERS,
     
+    // key errors
     INVALID_KEY_MISSING_KTY = 200,
     INVALID_KEY_WRONG_KTY,
     INVALID_KEY_MISSING_ALG,
@@ -35,5 +37,8 @@ export enum ErrorCode {
     INVALID_KEY_SCHEMA,
     INVALID_KEY_PRIVATE,
     INVALID_KEY_X5C,
-    INVALID_KEY_UNKNOWN
+    INVALID_KEY_UNKNOWN,
+
+    // config errors
+    OPENSSL_NOT_AVAILABLE = 300
 }

--- a/src/shcKeyValidator.ts
+++ b/src/shcKeyValidator.ts
@@ -12,6 +12,7 @@ import execa from 'execa';
 import fs from 'fs';
 import path from 'path';
 import {v4 as uuidv4} from 'uuid';
+import { isOpensslAvailable } from './utils'
 
 
 // directory where to write cert files for openssl validation
@@ -54,10 +55,8 @@ interface EcPublicJWK extends JWK.Key {
 // validate a JWK certificate chain (x5c value)
 function validateX5c(x5c: string[], log: Log): CertFields | undefined {
     // we use OpenSSL to validate the certificate chain, first check if present
-    try {
-        execa.commandSync("openssl version");
-    } catch (err) {
-        log.warn('OpenSSL not available to validate the X.509 certificate chain; skipping validation', ErrorCode.ERROR);
+    if (!isOpensslAvailable()) {
+        log.warn('OpenSSL not available to validate the X.509 certificate chain; skipping validation', ErrorCode.OPENSSL_NOT_AVAILABLE);
         return;
     }
     if (!fs.existsSync(tmpDir)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import pako from 'pako';
 import jose from 'node-jose';
-
+import execa from 'execa';
 
 export function parseJson<T>(json: string): T | undefined  {
     try {
@@ -55,4 +55,13 @@ export function inflatePayload(verificationResult: jose.JWS.VerificationResult):
     }
 
     return payload;
+}
+
+export function isOpensslAvailable(): boolean {
+    try {
+        execa.commandSync("openssl version");
+        return true;
+    } catch (err) {
+        return false;
+    }
 }

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -10,6 +10,8 @@ const testdataDir = './testdata/';
 
 const EXPECTED_SUBJECT_ALT_NAME = 'https://smarthealth.cards/examples/issuer';
 
+const OPENSSL_AVAILABLE = utils.isOpensslAvailable();
+
 async function testKey(fileName: string, subjectAltName: string = ''): Promise<ErrorCode[]> {
     const filePath = path.join(testdataDir, fileName);
     const result = (await verifyHealthCardIssuerKey(utils.loadJSONFromFile(filePath), undefined ,subjectAltName));
@@ -25,11 +27,11 @@ test("Keys: valid keys", async () => {
 });
 
 test("Keys: valid with x5c (3-cert chain)", async () => {
-    expect(await testKey('valid_key_with_x5c.json', EXPECTED_SUBJECT_ALT_NAME)).toHaveLength(0);
+    expect(await testKey('valid_key_with_x5c.json', EXPECTED_SUBJECT_ALT_NAME)).toHaveLength(OPENSSL_AVAILABLE ? 0 : 1);
 });
 
 test("Keys: valid with x5c (2-cert chain)", async () => {
-    expect(await testKey('valid_2_chain.public.json', EXPECTED_SUBJECT_ALT_NAME)).toHaveLength(0);
+    expect(await testKey('valid_2_chain.public.json', EXPECTED_SUBJECT_ALT_NAME)).toHaveLength(OPENSSL_AVAILABLE ? 0 : 1);
 });
 
 test("Keys: wrong key identifier (kid)", async () => {
@@ -57,21 +59,21 @@ test("Keys: private key", async () => {
 });
 
 test("Keys: wrong SAN in x5c cert", async () => {
-    expect(await testKey('valid_key_with_x5c.json', 'https://invalid.url')).toContain(ErrorCode.INVALID_KEY_X5C);
+    expect(await testKey('valid_key_with_x5c.json', 'https://invalid.url')).toContain(OPENSSL_AVAILABLE ? ErrorCode.INVALID_KEY_X5C : ErrorCode.OPENSSL_NOT_AVAILABLE);
 });
 
 test("Keys: wrong SAN in x5c cert (DNS prefix)", async () => {
-    expect(await testKey('invalid_DNS_SAN.public.json', EXPECTED_SUBJECT_ALT_NAME)).toContain(ErrorCode.INVALID_KEY_X5C);
+    expect(await testKey('invalid_DNS_SAN.public.json', EXPECTED_SUBJECT_ALT_NAME)).toContain(OPENSSL_AVAILABLE ? ErrorCode.INVALID_KEY_X5C : ErrorCode.OPENSSL_NOT_AVAILABLE);
 });
 
 test("Keys: no SAN in x5c cert", async () => {
-    expect(await testKey('invalid_no_SAN.public.json', EXPECTED_SUBJECT_ALT_NAME)).toContain(ErrorCode.INVALID_KEY_X5C);
+    expect(await testKey('invalid_no_SAN.public.json', EXPECTED_SUBJECT_ALT_NAME)).toContain(OPENSSL_AVAILABLE ? ErrorCode.INVALID_KEY_X5C : ErrorCode.OPENSSL_NOT_AVAILABLE);
 });
 
 test("Keys: key and x5c cert mismatch", async () => {
-    expect(await testKey('cert_mismatch.public.json')).toContain(ErrorCode.INVALID_KEY_X5C);
+    expect(await testKey('cert_mismatch.public.json')).toContain(OPENSSL_AVAILABLE ? ErrorCode.INVALID_KEY_X5C : ErrorCode.OPENSSL_NOT_AVAILABLE);
 });
 
 test("Keys: invalid x5c cert chain", async () => {
-    expect(await testKey('invalid_chain.public.json')).toContain(ErrorCode.INVALID_KEY_X5C);
+    expect(await testKey('invalid_chain.public.json')).toContain(OPENSSL_AVAILABLE ? ErrorCode.INVALID_KEY_X5C : ErrorCode.OPENSSL_NOT_AVAILABLE);
 });


### PR DESCRIPTION
Adjust tests expected result when OpenSSL is not available (to validate JWK's x5c cert chains)