### PR TITLE
Adjust expected test behavior if openssl is not present

### DIFF
--- a/tests/card.test.ts
+++ b/tests/card.test.ts
@@ -6,10 +6,9 @@ import { validateCard, ValidationType } from '../src/validate';
 import { getFileData } from '../src/file';
 import { ErrorCode } from '../src/error';
 import { LogLevels } from '../src/logger';
-
+import { isOpensslAvailable } from '../src/utils';
 
 const testdataDir = './testdata/';
-
 
 // wrap testcard with a function that returns a function - now we don't need all 'async ()=> await' for every test case
 function testCard(fileName: string | string[], fileType: ValidationType = 'healthcard', expected: (number | null | undefined | ErrorCode[])[] = [/*ERROR+FATAL*/0, /*WARNING*/0,/*INFO*/null,/*DEBUG*/null,/*FATAL*/null]) {
@@ -17,7 +16,6 @@ function testCard(fileName: string | string[], fileType: ValidationType = 'healt
          await _testCard(fileName, fileType, expected);
     }
 }
-
 
 async function _testCard(fileName: string | string[], fileType: ValidationType , expected: (number | null | undefined | ErrorCode[])[]): Promise<void> {
     
@@ -86,11 +84,15 @@ async function _testCard(fileName: string | string[], fileType: ValidationType ,
     or use the less-specific [0, 2]
 */
 
-
+// Check if openssl is available. If not, this will add a warning in many tests where an issuer key
+// set contains a key with a x5c value. Hard to automate because tests that fail before parsing the JWS
+// won't add this warning.
+const OPENSSL_AVAILABLE = isOpensslAvailable();
+const OPENSSL_WARNING = OPENSSL_AVAILABLE ? 0 : 1;
 // for now, we get many not-short-url warnings for every use of example-02'
 const SHORT_URL_WARNINGS = 55;
-const JWS_TOO_LONG_WARNING = 1;
 const SCHEMA_ERROR_ARRAY = Array.apply(null, Array(SHORT_URL_WARNINGS)).map(() => ErrorCode.SCHEMA_ERROR);
+const JWS_TOO_LONG_WARNING = 1;
 
 test("Cards: valid 00 FHIR bundle", testCard(['example-00-a-fhirBundle.json'], "fhirbundle"));
 test("Cards: valid 01 FHIR bundle", testCard(['example-01-a-fhirBundle.json'], "fhirbundle"));
@@ -104,49 +106,49 @@ test("Cards: valid 00 JWS payload minified", testCard(['example-00-c-jws-payload
 test("Cards: valid 01 JWS payload minified", testCard(['example-01-c-jws-payload-minified.json'], "jwspayload"));
 test("Cards: valid 02 JWS payload minified", testCard(['example-02-c-jws-payload-minified.json'], "jwspayload", [0, SHORT_URL_WARNINGS]));
 
-test("Cards: valid 00 JWS", testCard(['example-00-d-jws.txt'], "jws"));
-test("Cards: valid 01 JWS", testCard(['example-01-d-jws.txt'], "jws"));
-test("Cards: valid 02 JWS", testCard(['example-02-d-jws.txt'], "jws", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+test("Cards: valid 00 JWS", testCard(['example-00-d-jws.txt'], "jws", [0, OPENSSL_WARNING]));
+test("Cards: valid 01 JWS", testCard(['example-01-d-jws.txt'], "jws", [0, OPENSSL_WARNING]));
+test("Cards: valid 02 JWS", testCard(['example-02-d-jws.txt'], "jws", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING + OPENSSL_WARNING]));
 
-test("Cards: valid 00 health card", testCard(['example-00-e-file.smart-health-card'], "healthcard"));
-test("Cards: valid 01 health card", testCard(['example-01-e-file.smart-health-card'], "healthcard"));
-test("Cards: valid 02 health card", testCard(['example-02-e-file.smart-health-card'], "healthcard", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+test("Cards: valid 00 health card", testCard(['example-00-e-file.smart-health-card'], "healthcard", [0, OPENSSL_WARNING]));
+test("Cards: valid 01 health card", testCard(['example-01-e-file.smart-health-card'], "healthcard", [0, OPENSSL_WARNING]));
+test("Cards: valid 02 health card", testCard(['example-02-e-file.smart-health-card'], "healthcard", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING + OPENSSL_WARNING]));
 
-test("Cards: valid 00 QR numeric", testCard(['example-00-f-qr-code-numeric-value-0.txt'], "qrnumeric"));
-test("Cards: valid 01 QR numeric", testCard(['example-01-f-qr-code-numeric-value-0.txt'], "qrnumeric"));
+test("Cards: valid 00 QR numeric", testCard(['example-00-f-qr-code-numeric-value-0.txt'], "qrnumeric", [0, OPENSSL_WARNING]));
+test("Cards: valid 01 QR numeric", testCard(['example-01-f-qr-code-numeric-value-0.txt'], "qrnumeric", [0, OPENSSL_WARNING]));
 test("Cards: valid 02 QR numeric",  
     testCard(['example-02-f-qr-code-numeric-value-0.txt',
         'example-02-f-qr-code-numeric-value-1.txt',
-        'example-02-f-qr-code-numeric-value-2.txt'], "qrnumeric", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+        'example-02-f-qr-code-numeric-value-2.txt'], "qrnumeric", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING + OPENSSL_WARNING]));
 test("Cards: valid 02 QR numeric (out of order)", 
     testCard(['example-02-f-qr-code-numeric-value-1.txt',
         'example-02-f-qr-code-numeric-value-0.txt',
-        'example-02-f-qr-code-numeric-value-2.txt'], "qrnumeric", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+        'example-02-f-qr-code-numeric-value-2.txt'], "qrnumeric", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING + OPENSSL_WARNING]));
 
-test("Cards: valid 00 QR code", testCard(['example-00-g-qr-code-0.svg'], "qr"));
-test("Cards: valid 01 QR code", testCard(['example-01-g-qr-code-0.svg'], "qr"));
+test("Cards: valid 00 QR code", testCard(['example-00-g-qr-code-0.svg'], "qr", [0, OPENSSL_WARNING]));
+test("Cards: valid 01 QR code", testCard(['example-01-g-qr-code-0.svg'], "qr", [0, OPENSSL_WARNING]));
 
 test("Cards: valid 02 QR code", 
-    testCard(['example-02-g-qr-code-0.svg', 'example-02-g-qr-code-1.svg', 'example-02-g-qr-code-2.svg'], "qr", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+    testCard(['example-02-g-qr-code-0.svg', 'example-02-g-qr-code-1.svg', 'example-02-g-qr-code-2.svg'], "qr", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING + OPENSSL_WARNING]));
 
 test("Cards: valid 02 QR code PNG", 
-    testCard(['example-02-g-qr-code-0.png', 'example-02-g-qr-code-1.png', 'example-02-g-qr-code-2.png'], "qr", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+    testCard(['example-02-g-qr-code-0.png', 'example-02-g-qr-code-1.png', 'example-02-g-qr-code-2.png'], "qr", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING + OPENSSL_WARNING]));
 
 test("Cards: valid 02 QR code JPG", 
-    testCard(['example-02-g-qr-code-0.jpg', 'example-02-g-qr-code-1.jpg', 'example-02-g-qr-code-2.jpg'], "qr", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+    testCard(['example-02-g-qr-code-0.jpg', 'example-02-g-qr-code-1.jpg', 'example-02-g-qr-code-2.jpg'], "qr", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING + OPENSSL_WARNING]));
 
 test("Cards: valid 02 QR code BMP",
-    testCard(['example-02-g-qr-code-0.bmp', 'example-02-g-qr-code-1.bmp', 'example-02-g-qr-code-2.bmp'], "qr", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING]));
+    testCard(['example-02-g-qr-code-0.bmp', 'example-02-g-qr-code-1.bmp', 'example-02-g-qr-code-2.bmp'], "qr", [0, SHORT_URL_WARNINGS + JWS_TOO_LONG_WARNING + OPENSSL_WARNING]));
 
 // Warning cases
 
 test("Cards: fhir bundle w/ trailing chars", testCard(['test-example-00-a-fhirBundle-trailing_chars.json'], 'fhirbundle', [0, [ErrorCode.TRAILING_CHARACTERS]]));
 test("Cards: jws payload w/ trailing chars", testCard('test-example-00-b-jws-payload-expanded-trailing_chars.json', 'jwspayload', [0, [ErrorCode.TRAILING_CHARACTERS]]));
-test("Cards: jws w/ trailing chars", testCard('test-example-00-d-jws-trailing_chars.txt', 'jws', [0, [ErrorCode.TRAILING_CHARACTERS]]));
-test("Cards: health card w/ trailing chars", testCard('test-example-00-e-file-trailing_chars.smart-health-card', 'healthcard', [0, [ErrorCode.TRAILING_CHARACTERS]]));
-test("Cards: numeric QR w/ trailing chars", testCard('test-example-00-f-qr-code-numeric-value-0-trailing_chars.txt', 'qrnumeric', [0, [ErrorCode.TRAILING_CHARACTERS]]));
+test("Cards: jws w/ trailing chars", testCard('test-example-00-d-jws-trailing_chars.txt', 'jws', [0, [ErrorCode.TRAILING_CHARACTERS].concat(OPENSSL_AVAILABLE ? [] : [ErrorCode.OPENSSL_NOT_AVAILABLE])]));
+test("Cards: health card w/ trailing chars", testCard('test-example-00-e-file-trailing_chars.smart-health-card', 'healthcard', [0, [ErrorCode.TRAILING_CHARACTERS].concat(OPENSSL_AVAILABLE ? [] : [ErrorCode.OPENSSL_NOT_AVAILABLE])]));
+test("Cards: numeric QR w/ trailing chars", testCard('test-example-00-f-qr-code-numeric-value-0-trailing_chars.txt', 'qrnumeric', [0, [ErrorCode.TRAILING_CHARACTERS].concat(OPENSSL_AVAILABLE ? [] : [ErrorCode.OPENSSL_NOT_AVAILABLE])]));
 
-test("Cards: jws too long", testCard('example-02-d-jws.txt', 'jws', [0, [ErrorCode.JWS_TOO_LONG].concat(SCHEMA_ERROR_ARRAY)]));
+test("Cards: jws too long", testCard('example-02-d-jws.txt', 'jws', [0, [ErrorCode.JWS_TOO_LONG].concat(OPENSSL_AVAILABLE ? [] : [ErrorCode.OPENSSL_NOT_AVAILABLE]).concat(SCHEMA_ERROR_ARRAY)]));
 
 // Error cases
 
@@ -164,12 +166,12 @@ test("Cards: invalid issuer url",
 
 // the JWK's x5c value has the correct URL, so we get an extra x5c error due to URL mismatch
 test("Cards: invalid issuer url (http)", 
-    testCard(['test-example-00-e-file-invalid_issuer_url_http.smart-health-card'], 'healthcard', [[ErrorCode.INVALID_ISSUER_URL, ErrorCode.INVALID_KEY_X5C]])
+    testCard(['test-example-00-e-file-invalid_issuer_url_http.smart-health-card'], 'healthcard', [[ErrorCode.INVALID_ISSUER_URL].concat(OPENSSL_AVAILABLE ? [ErrorCode.INVALID_KEY_X5C] : []), OPENSSL_WARNING])
 );
 
 // the JWK's x5c value has the correct URL, so we get an extra x5c error due to URL mismatch
 test("Cards: invalid issuer url (trailing /)", 
-    testCard(['test-example-00-e-file-issuer_url_with_trailing_slash.smart-health-card'], 'healthcard', [[ErrorCode.INVALID_ISSUER_URL, ErrorCode.INVALID_KEY_X5C]])
+    testCard(['test-example-00-e-file-issuer_url_with_trailing_slash.smart-health-card'], 'healthcard', [[ErrorCode.INVALID_ISSUER_URL].concat(OPENSSL_AVAILABLE ? [ErrorCode.INVALID_KEY_X5C] : []), OPENSSL_WARNING])
 );
 
 test("Cards: invalid QR header", 
@@ -177,15 +179,15 @@ test("Cards: invalid QR header",
 );
 
 test("Cards: wrong file extension", 
-    testCard(['test-example-00-e-file.wrong-extension'], 'healthcard', [0, [ErrorCode.INVALID_FILE_EXTENSION]])
+    testCard(['test-example-00-e-file.wrong-extension'], 'healthcard', [0, [ErrorCode.INVALID_FILE_EXTENSION].concat(OPENSSL_AVAILABLE ? [] : [ErrorCode.OPENSSL_NOT_AVAILABLE])])
 );
 
 test("Cards: invalid signature", 
-    testCard(['test-example-00-d-jws-invalid-signature.txt'], 'jws', [[ErrorCode.JWS_VERIFICATION_ERROR]])
+    testCard(['test-example-00-d-jws-invalid-signature.txt'], 'jws', [[ErrorCode.JWS_VERIFICATION_ERROR], OPENSSL_WARNING])
 );
 
 test("Cards: invalid single chunk QR header", 
-    testCard(['test-example-00-f-qr-code-numeric-value-0-wrong-multi-chunk.txt'], 'qrnumeric', [0, [ErrorCode.INVALID_NUMERIC_QR_HEADER]])
+    testCard(['test-example-00-f-qr-code-numeric-value-0-wrong-multi-chunk.txt'], 'qrnumeric', [0, [ErrorCode.INVALID_NUMERIC_QR_HEADER].concat(OPENSSL_AVAILABLE ? [] : [ErrorCode.OPENSSL_NOT_AVAILABLE])])
 );
 
 test("Cards: missing QR chunk", 
@@ -201,7 +203,7 @@ test("Cards: QR chunk index out of range",
 );
 
 test("Cards: QR chunk too big",
-    testCard(['test-example-02-f-qr-code-numeric-value-0-qr_chunk_too_big.txt', 'test-example-02-f-qr-code-numeric-value-1-qr_chunk_too_big.txt'], 'qrnumeric', [[ErrorCode.INVALID_NUMERIC_QR, ErrorCode.INVALID_NUMERIC_QR], /*1 JWS_TOO_LONG + 55 short ref warnings*/ 56])
+    testCard(['test-example-02-f-qr-code-numeric-value-0-qr_chunk_too_big.txt', 'test-example-02-f-qr-code-numeric-value-1-qr_chunk_too_big.txt'], 'qrnumeric', [[ErrorCode.INVALID_NUMERIC_QR, ErrorCode.INVALID_NUMERIC_QR], JWS_TOO_LONG_WARNING + SHORT_URL_WARNINGS + OPENSSL_WARNING])
 );
 
 test("Cards: valid 00 FHIR bundle with non-dm properties", testCard(['test-example-00-a-non-dm-properties.json'], "fhirbundle", [0, 5 /*5x ErrorCode.SCHEMA_ERROR*/]));

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -6,14 +6,15 @@ import fs from 'fs';
 import { ErrorCode } from '../src/error';
 import { LogItem } from '../src/logger';
 import { CliOptions } from '../src/shc-validator';
+import { isOpensslAvailable } from '../src/utils';
 
+const OPENSSL_AVAILABLE = isOpensslAvailable();
 
 interface LogEntry {
     time: string,
     options: CliOptions,
     log: LogItem[]
 }
-
 
 function runCommand(command: string) {
     try {
@@ -127,7 +128,7 @@ test("Logs: valid 00-e health card single log file", () => {
 
     const logFile = 'log-00-e-single.txt';
     const expectedEntries = 1;
-    const expectedLogItems = 7;
+    const expectedLogItems = 7 + (OPENSSL_AVAILABLE ? 0 : 1);
 
     runCommand('node . --path testdata/example-00-e-file.smart-health-card --type healthcard --loglevel info  --logout ' + logFile);
 
@@ -142,7 +143,7 @@ test("Logs: valid 00-e health card append log file", () => {
 
     const logFile = 'log-00-e-append.txt';
     const expectedEntries = 2;
-    const expectedLogItems = [7, 7];
+    const expectedLogItems = [7 + (OPENSSL_AVAILABLE ? 0 : 1), 7 + (OPENSSL_AVAILABLE ? 0 : 1)];
 
     runCommand('node . --path testdata/example-00-e-file.smart-health-card --type healthcard --loglevel info  --logout ' + logFile);
     runCommand('node . --path testdata/example-00-e-file.smart-health-card --type healthcard --loglevel info  --logout ' + logFile);

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -10,6 +10,8 @@ const testdataDir = './testdata/';
 
 const EXPECTED_SUBJECT_ALT_NAME = 'https://smarthealth.cards/examples/issuer';
 
+// Check if openssl is available. If not, this will add a warning in tests where an issuer key
+// set contains a key with a x5c value.
 const OPENSSL_AVAILABLE = utils.isOpensslAvailable();
 
 async function testKey(fileName: string, subjectAltName: string = ''): Promise<ErrorCode[]> {


### PR DESCRIPTION
Don't expect x5c-related errors if openssl is not available