### PR TITLE
Fix failing openssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project provides a tool to help implementers of the [SMART Health Card Fram
 
 ## Setup
 
-1. Make sure [node.js](https://nodejs.org/) and [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) are installed on your system; the latest Long-Term Support (LTS) version is recommended for both. [OpenSSL](https://www.openssl.org/) is also needed to validate certificate chains which could be present in issuer JSON Web Keys (`x5c` value); if absent, chain validation is skipped.
+1. Make sure [node.js](https://nodejs.org/) and [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) are installed on your system; the latest Long-Term Support (LTS) version is recommended for both. [OpenSSL 1.1.1](https://www.openssl.org/) is also needed to validate certificate chains which could be present in issuer JSON Web Keys (`x5c` value); if absent, chain validation is skipped.
 
 2. Get the source, for example using git:
 

--- a/src/shcKeyValidator.ts
+++ b/src/shcKeyValidator.ts
@@ -90,15 +90,10 @@ function validateX5c(x5c: string[], log: Log): CertFields | undefined {
         //
         const opensslVerifyCommand = "openssl verify " + rootCaArg + caArg + issuerCert;
         log.debug('Calling openssl for x5c validation: ' + opensslVerifyCommand);
-        try {
-            const result = execa.commandSync(opensslVerifyCommand);
-            if (result.exitCode != 0) {
-                log.debug(result.stderr);
-                throw 'OpenSSL returned an error: exit code ' + result.exitCode;
-            }
-        } catch (err) {
-            log.warn('OpenSSL error while validating the X.509 certificate chain; skipping validation', ErrorCode.OPENSSL_NOT_AVAILABLE);
-            return;
+        let result = execa.commandSync(opensslVerifyCommand);
+        if (result.exitCode != 0) {
+            log.debug(result.stderr);
+            throw 'OpenSSL returned an error: exit code ' + result.exitCode;
         }
 
         //
@@ -115,15 +110,10 @@ function validateX5c(x5c: string[], log: Log): CertFields | undefined {
         //   <multi-line base64 encoded key>
         //   -----END PUBLIC KEY-----
         log.debug('Calling openssl for parsing issuer cert: ' + opensslX509Command);
-        try {
-            const result = execa.commandSync(opensslX509Command);
-            if (result.exitCode != 0) {
-                log.debug(result.stderr);
-                throw 'OpenSSL returned an error: exit code ' + result.exitCode;
-            }
-        } catch (err) {
-            log.warn('OpenSSL error while validating the X.509 certificate chain; skipping validation', ErrorCode.OPENSSL_NOT_AVAILABLE);
-            return;
+        result = execa.commandSync(opensslX509Command);
+        if (result.exitCode != 0) {
+            log.debug(result.stderr);
+            throw 'OpenSSL returned an error: exit code ' + result.exitCode;
         }
         
         //

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import pako from 'pako';
 import jose from 'node-jose';
 import execa from 'execa';
+import { stdout } from 'node:process';
 
 export function parseJson<T>(json: string): T | undefined  {
     try {
@@ -59,8 +60,10 @@ export function inflatePayload(verificationResult: jose.JWS.VerificationResult):
 
 export function isOpensslAvailable(): boolean {
     try {
-        execa.commandSync("openssl version");
-        return true;
+        const expectedPrefix = 'OpenSSL 1.1.1'; // the x5c validation currently only works with openssl 1.1.1
+        const result = execa.commandSync("openssl version");
+        return (result.exitCode == 0 &&
+                result.stdout.substr(0, expectedPrefix.length) == expectedPrefix);
     } catch (err) {
         return false;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,7 +63,7 @@ export function isOpensslAvailable(): boolean {
         const expectedPrefix = 'OpenSSL 1.1.1'; // the x5c validation currently only works with openssl 1.1.1
         const result = execa.commandSync("openssl version");
         return (result.exitCode == 0 &&
-                result.stdout.substr(0, expectedPrefix.length) == expectedPrefix);
+                result.stdout.substr(0, expectedPrefix.length) === expectedPrefix);
     } catch (err) {
         return false;
     }


### PR DESCRIPTION
Stop gap fix to issue #47 (and potentially #38) to make sure openssl 1.1.1 is installed before validating x5c chains (until the code logic can workaround older/forked versions of openssl.