### PR TITLE
Skip JWK set download if provided on command line

### DIFF
--- a/src/jws-compact.ts
+++ b/src/jws-compact.ts
@@ -11,7 +11,8 @@ import got from 'got';
 import jose from 'node-jose';
 import Log from './logger';
 import { ValidationResult } from './validate';
-import { verifyHealthCardIssuerKey } from './shcKeyValidator';
+import { verifyAndImportHealthCardIssuerKey } from './shcKeyValidator';
+import { globalOptions } from './shc-validator';
 
 
 export const schema = jwsCompactSchema;
@@ -151,8 +152,11 @@ export async function validate(jws: JWS): Promise<ValidationResult> {
     }
 
     // download the keys into the keystore. if it fails, continue an try to use whatever is in the keystore.
-    await downloadKey(payload.iss, log);
-
+    if (payload.iss && !globalOptions.skipJwksDownload) {
+        await downloadAndImportKey(payload.iss, log);
+    } else {
+        log.info("skipping issuer JWK set download");
+    }
 
     if (await verifyJws(jws, log)) {
         log.info("JWS signature verified");
@@ -165,20 +169,25 @@ export async function validate(jws: JWS): Promise<ValidationResult> {
 }
 
 
-async function downloadKey(issuerURL: string, log: Log): Promise<keys.KeySet | undefined> {
+async function downloadAndImportKey(issuerURL: string, log: Log): Promise<keys.KeySet | undefined> {
 
     const jwkURL = issuerURL + '/.well-known/jwks.json';
     log.info("Retrieving issuer key from " + jwkURL);
 
-    return await got(jwkURL).json<keys.KeySet>()
-        // TODO: split up download/parsing to provide finer-grained error message
+    return await got(jwkURL, {timeout: 5000}).json<keys.KeySet>()
         .then(async keySet => {
             log.debug("Downloaded issuer key(s) : ");
-            return (await verifyHealthCardIssuerKey(keySet, log, issuerURL)).result as (keys.KeySet | undefined);
+            let result;
+            try {
+                result = (await verifyAndImportHealthCardIssuerKey(keySet, log, issuerURL)).result as (keys.KeySet | undefined)
+            } catch (err) {
+                log.error("Can't parse downloaded issuer JWK set: " + err, ErrorCode.ISSUER_KEY_DOWNLOAD_ERROR);
+                return undefined;
+            }
+            return result;
         })
-        .catch(() => {
-            log.error("Can't parse downloaded issuer keys as a key set",
-                ErrorCode.ISSUER_KEY_DOWNLOAD_ERROR);
+        .catch(err => {
+            log.error("Failed to download issuer JWK set: " + err, ErrorCode.ISSUER_KEY_DOWNLOAD_ERROR);
             return undefined;
         });
 

--- a/src/shc-validator.ts
+++ b/src/shc-validator.ts
@@ -47,7 +47,9 @@ export interface CliOptions {
     fhirout: string;
     exclude: string[];
 }
-
+export const globalOptions = {
+    skipJwksDownload: false
+}
 
 function exit(message: string, exitCode: ErrorCode = 0): void {
     process.exitCode = exitCode;
@@ -62,9 +64,11 @@ async function processOptions(options: CliOptions) {
 
     console.log("SMART Health Card Validation SDK v" + npmpackage.version);
 
+
     // check the latest SDK and spec version
     const vLatestSDK = versions.latestSdkVersion();
     const vLatestSpec = versions.latestSpecVersion();
+
 
     // map the --loglevel option to the Log.LogLevel enum
     const level = loglevelChoices.indexOf(options.loglevel) as LogLevels;
@@ -83,6 +87,10 @@ async function processOptions(options: CliOptions) {
     if (options.exclude) {
         Log.Exclusions = getExcludeErrorCodes(options.exclude);
     }
+
+
+    // set global options
+    globalOptions.skipJwksDownload = !!options.jwkset;
 
 
     // verify that the directory of the fhir output file exists, if provided

--- a/src/shc-validator.ts
+++ b/src/shc-validator.ts
@@ -15,6 +15,7 @@ import { KeySet } from './keys';
 import { FhirLogOutput } from './fhirBundle';
 import * as versions from './check-for-update';
 import semver from 'semver';
+import { JwsValidationOptions } from './jws-compact';
 
 /**
  *  Defines the program
@@ -47,9 +48,7 @@ export interface CliOptions {
     fhirout: string;
     exclude: string[];
 }
-export const globalOptions = {
-    skipJwksDownload: false
-}
+
 
 function exit(message: string, exitCode: ErrorCode = 0): void {
     process.exitCode = exitCode;
@@ -90,7 +89,9 @@ async function processOptions(options: CliOptions) {
 
 
     // set global options
-    globalOptions.skipJwksDownload = !!options.jwkset;
+
+
+    JwsValidationOptions.skipJwksDownload = !!options.jwkset;
 
 
     // verify that the directory of the fhir output file exists, if provided

--- a/src/shcKeyValidator.ts
+++ b/src/shcKeyValidator.ts
@@ -160,7 +160,7 @@ function validateX5c(x5c: string[], log: Log): CertFields | undefined {
     }
 }
 
-export async function verifyHealthCardIssuerKey(keySet: KeySet, log = new Log('Validate Key-Set'), expectedSubjectAltName = ''): Promise<ValidationResult> {
+export async function verifyAndImportHealthCardIssuerKey(keySet: KeySet, log = new Log('Validate Key-Set'), expectedSubjectAltName = ''): Promise<ValidationResult> {
 
     // check that keySet is valid
     if (!(keySet instanceof Object) || !keySet.keys || !(keySet.keys instanceof Array)) {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import Log from './logger';
-import { verifyHealthCardIssuerKey } from './shcKeyValidator';
+import { verifyAndImportHealthCardIssuerKey } from './shcKeyValidator';
 import { FileInfo } from './file';
 import { ErrorCode } from './error';
 import * as healthCard from './healthCard';
@@ -27,7 +27,7 @@ export class ValidationResult {
 
 /** Validate the issuer key */
 export async function validateKey(keySet: KeySet): Promise<ValidationResult> {
-    return await verifyHealthCardIssuerKey(keySet);
+    return await verifyAndImportHealthCardIssuerKey(keySet);
 }
 
 

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -4,7 +4,7 @@
 import path from 'path';
 import { ErrorCode } from '../src/error';
 import { LogLevels } from '../src/logger';
-import { verifyHealthCardIssuerKey } from '../src/shcKeyValidator';
+import { verifyAndImportHealthCardIssuerKey } from '../src/shcKeyValidator';
 import * as utils from '../src/utils';
 const testdataDir = './testdata/';
 
@@ -16,7 +16,7 @@ const OPENSSL_AVAILABLE = utils.isOpensslAvailable();
 
 async function testKey(fileName: string, subjectAltName: string = ''): Promise<ErrorCode[]> {
     const filePath = path.join(testdataDir, fileName);
-    const result = (await verifyHealthCardIssuerKey(utils.loadJSONFromFile(filePath), undefined ,subjectAltName));
+    const result = (await verifyAndImportHealthCardIssuerKey(utils.loadJSONFromFile(filePath), undefined ,subjectAltName));
     return result.log.flatten(LogLevels.WARNING).map(item => item.code);
 }
 


### PR DESCRIPTION
Skip issuer JWK set download if provided on the command-line, plus other download clean-ups (timeout, split download/parsing errors). Fixes #53.