### PR TITLE
break out of loop when property in unknown; enable 'allErrors' in ajv;

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -21,7 +21,7 @@ export function validateSchema(schema: AnySchemaObject, data: FhirBundle | JWS |
     try {
 
         if (!schemaCache[schemaId]) {
-            const ajv = new Ajv({ strict: false, allErrors: false });
+            const ajv = new Ajv({ strict: false, allErrors: true });
             if(schema.$ref) {
                 schemaCache[schemaId] = ajv.addSchema(fhirSchema).compile(schema);
             } else {
@@ -85,9 +85,9 @@ export function objPathToSchema(path: string) : string {
             p = p.properties[properties[i]];
 
             // this property is not valid according to the schema
-            if (!p) {
+            if (p == null) {
                 t = "unknown";
-                continue;
+                break;
             }
 
             // directly has a ref, then it is that type


### PR DESCRIPTION
Fixed condition where using invalid property in fhir resource caused an error in validation.
Enabled the 'allErrors' property in AJV to display multiple schema issues to the user instead of just the first issue.
Fixes #67.