### PR TITLE
Disallow empty fhir elements

### DIFF
--- a/schema/immunization-dm.json
+++ b/schema/immunization-dm.json
@@ -48,6 +48,15 @@
         "path": "Immunization.statusReason"
     },
     {
+        "path": "Immunization.patient.type"
+    },
+    {
+        "path": "Immunization.patient.identifier"
+    },
+    {
+        "path": "Immunization.patient.display"
+    },
+    {
         "path": "Immunization.encounter"
     },
     {
@@ -63,7 +72,13 @@
         "path": "Immunization.location"
     },
     {
-        "path": "Immunization.manufacturer"
+        "path": "Immunization.manufacturer.reference"
+    },
+    {
+        "path": "Immunization.manufacturer.type"
+    },
+    {
+        "path": "Immunization.manufacturer.display"
     },
     {
         "path": "Immunization.expirationDate"

--- a/schema/patient-dm.json
+++ b/schema/patient-dm.json
@@ -81,12 +81,6 @@
         "path": "Patient.contact"
     },
     {
-        "path": "Patient.contact.address.text"
-    },
-    {
-        "path": "Patient.contact.address.line"
-    },
-    {
         "path": "Patient.communication"
     },
     {

--- a/src/fhirBundle.ts
+++ b/src/fhirBundle.ts
@@ -66,7 +66,9 @@ export function validate(fhirBundleText: string): ValidationResult {
         }
     }
 
-
+    //
+    // Validate each resource of .entry[]
+    //
     for (let i = 0; i < fhirBundle.entry.length; i++) {
 
         const entry = fhirBundle.entry[i];
@@ -112,6 +114,14 @@ export function validate(fhirBundleText: string): ValidationResult {
 
             if (propType === 'Reference' && o['reference'] && !/[^:]+:\d+/.test(o['reference'] as string)) {
                 log.warn('fhirBundle.entry[' + i.toString() + ']' + ".resource." + path.join('.') + " (Reference) should be short resource-scheme URIs (e.g., {“patient”: {“reference”: “resource:0”}})", ErrorCode.SCHEMA_ERROR);
+            }
+
+            if (  // warn on empty string, empty object, empty array
+                (o instanceof Array && o.length === 0) ||
+                (typeof o === 'string' && o === '') ||
+                (o instanceof Object && Object.keys(o).length === 0)
+            ) {
+                log.error('fhirBundle.entry[' + i.toString() + ']' + ".resource." + path.join('.') + " is empty. Empty elements are invalid.", ErrorCode.FHIR_SCHEMA_ERROR);
             }
 
         });

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -76,6 +76,9 @@ export function objPathToSchema(path: string) : string {
     const properties = path.split('.');
 
     let p = schema.definitions[properties[0]];
+    if(p == null) return 'unknown';
+
+
     let t = properties[0];
 
     for (let i = 1; i < properties.length; i++) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,6 +94,7 @@ export function walkProperties(obj: Record<string, unknown>, path: string[], cal
                 walkProperties(element, path.slice(0), callback);
             }
         }
+        if(obj.length === 0) callback(obj, path);
         return;
     }
 

--- a/testdata/test-example-00-a-fhirBundle-empty-values.json
+++ b/testdata/test-example-00-a-fhirBundle-empty-values.json
@@ -8,7 +8,6 @@
         "resourceType": "Patient",
         "name": [
           {
-            "id": "Patient-ID",
             "family": "Anyperson",
             "given": [
               "John",
@@ -22,36 +21,10 @@
     {
       "fullUrl": "resource:1",
       "resource": {
-        "resourceType": "Patient",
-        "name": [
-          {
-            "family": "Anyperson",
-            "given": [
-              "Joe",
-              "B."
-            ]
-          }
-        ],
-        "birthDate": "1951-01-20"
-      }
-    },
-    {
-      "fullUrl": "resource:2",
-      "resource": {
-        "resourceType": "Medication"
-      }
-    },
-    {
-      "fullUrl": "resource:3",
-      "resource": {
         "resourceType": "Immunization",
         "status": "completed",
         "vaccineCode": {
-          "coding": [
-            {
-              "system": "http://hl7.org/fhir/sid/cvx"
-            }
-          ]
+          "coding": []
         },
         "patient": {
           "reference": "resource:0"
@@ -64,12 +37,11 @@
             }
           }
         ],
-        "location": "Safeway Parking Lot",
         "lotNumber": "0000001"
       }
     },
     {
-      "fullUrl": "resource:4",
+      "fullUrl": "resource:2",
       "resource": {
         "resourceType": "Immunization",
         "status": "completed",
@@ -77,7 +49,7 @@
           "coding": [
             {
               "system": "http://hl7.org/fhir/sid/cvx",
-              "code": "217"
+              "code": "207"
             }
           ]
         },
@@ -87,12 +59,10 @@
         "occurrenceDateTime": "2021-01-29",
         "performer": [
           {
-            "actor": {
-              "display": "ABC General Hospital"
-            }
+            "actor": {}
           }
         ],
-        "lotNumber": "0000007"
+        "lotNumber": ""
       }
     }
   ]

--- a/tests/card.test.ts
+++ b/tests/card.test.ts
@@ -291,3 +291,6 @@ test("Cards: health card w/ multi-jws and issues",
 
 test("Cards: fhir bundle w/ usa-profile errors", testCard(['test-example-00-a-fhirBundle-profile-usa.json'], 'fhirbundle',
     [[ErrorCode.PROFILE_ERROR, ErrorCode.PROFILE_ERROR, ErrorCode.PROFILE_ERROR, ErrorCode.PROFILE_ERROR, ErrorCode.PROFILE_ERROR]], { profile: 'usa-covid19-immunization' }));
+
+test("Cards: fhir bundle w/ empty elements", testCard(['test-example-00-a-fhirBundle-empty-values.json'], 'fhirbundle',
+    [[ErrorCode.FHIR_SCHEMA_ERROR, ErrorCode.FHIR_SCHEMA_ERROR, ErrorCode.FHIR_SCHEMA_ERROR, ErrorCode.FHIR_SCHEMA_ERROR]]));


### PR DESCRIPTION
- Log schema error whenever FHIR element is {}, [], ""
- Updated usa dm schema files as the source schema has been updated.
- Added card test with empty elements

closes #90 