### PR TITLE
Simplified schema errors

### DIFF
--- a/src/fhirBundle.ts
+++ b/src/fhirBundle.ts
@@ -74,12 +74,22 @@ export function validate(fhirBundleText: string): ValidationResult {
         const entry = fhirBundle.entry[i];
         const resource = entry.resource;
 
-        validateSchema({ $ref: 'https://smarthealth.cards/schema/fhir-schema.json#/definitions/' + resource.resourceType }, resource, log, ['', 'entry', i.toString(), resource.resourceType].join('/'));
-
         if (resource == null) {
-            log.error("Bundle.entry[" + i.toString() + "].resource missing");
+            log.error("Schema: entry[" + i.toString() + "].resource missing");
             continue;
         }
+
+        if(!resource.resourceType) {
+            log.error("Schema: entry[" + i.toString() + "].resource.resourceType missing");
+            continue;
+        }
+
+        if(!(fhirSchema.definitions as Record<string, unknown>)[resource.resourceType]) {
+            log.error("Schema: entry[" + i.toString() + "].resource.resourceType missing");
+            continue;
+        }
+
+        validateSchema({ $ref: 'https://smarthealth.cards/schema/fhir-schema.json#/definitions/' + resource.resourceType }, resource, log, ['', 'entry', i.toString(), resource.resourceType].join('/'));
 
         if (resource.id) {
             log.warn("Bundle.entry[" + i.toString() + "].resource[" + resource.resourceType + "] should not include .id elements", ErrorCode.FHIR_SCHEMA_ERROR);


### PR DESCRIPTION
- simplified ajv's schema errors to a  more understandable form
- added some additional fhir pre-schema checks to prevent sending unknown resources to the validator.